### PR TITLE
IE11 bugfix

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,13 +5,12 @@ export function convertBreakpointsToMediaQueries(breakpoints) {
   const values = keys.map(key => breakpoints[key])
   const breakpointValues = [0, ...values.slice(0, -1)]
   const mediaQueries = breakpointValues.reduce((sum, value, index) => {
-    const options = Object.assign(
+    const mediaQuery = json2mq(Object.assign(
       {
         minWidth: value,
       },
       index < keys.length - 1 ? { maxWidth: breakpointValues[index+1] - 1 } : {}
-    )
-    const mediaQuery = json2mq(options)
+    ))
     return Object.assign(
       sum,
       {


### PR DESCRIPTION
Firstly thanks for the great plugin, it's been very useful.

I've found an issue including this plugin in my project (which needs IE11 support) and running it through Babel (to enable new ES6 support in order browsers like IE11). The issue is in helpers.js where Object.assign() is used. See the 'Caveats' section of this page:
https://babeljs.io/docs/plugins/transform-object-assign/

This PR fixes the caveatted issue, so that Babel can compile the JS.

The 'dist' folder files would need to be generated before it can be merged.