### PR TITLE
Object.keys order is not guaranteed

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,6 +2,7 @@ import json2mq from 'json2mq'
 
 export function convertBreakpointsToMediaQueries(breakpoints) {
   const keys = Object.keys(breakpoints)
+  keys.sort((a,b) => breakpoints[a]-breakpoints[b])
   const values = keys.map(key => breakpoints[key])
   const breakpointValues = [0, ...values.slice(0, -1)]
   const mediaQueries = breakpointValues.reduce((sum, value, index) => {


### PR DESCRIPTION
The keys array is not guaranteed to be in the same order that the user passed, and in any case the user was not required (in documentation) to pass an ordered Object because there simply isn't "ordered Object"