### PR TITLE
fix doc install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Vue.use(VueMq, {
     sm: 450,
     md: 1250,
     lg: Infinity,
-  }
+  },
   defaultBreakpoint: 'sm' // customize this for SSR
 })
 ```


### PR DESCRIPTION
What's new?
The example in the doc has a missing punctuation.